### PR TITLE
Fix name of variable to match println message

### DIFF
--- a/docs/slide-37.html
+++ b/docs/slide-37.html
@@ -127,7 +127,7 @@
 
                 <div id="content" class="content">
                     <main>
-                        <a class="header" href="#automatic-memory-reclamation" id="automatic-memory-reclamation"><h1>Automatic memory reclamation</h1></a>
+                        <h1><a class="header" href="#automatic-memory-reclamation" id="automatic-memory-reclamation">Automatic memory reclamation</a></h1>
 <p><code>Box::new(node)</code> allocates on the heap and <code>node</code> is <em>moved</em> inside the box. Ownership of the box can move, but you
 can only get a reference to its content.</p>
 <p>The memory is automatically freed when the box has no more owner (it is &quot;dropped&quot;).</p>
@@ -140,8 +140,8 @@ impl Drop for DropTracer {
 }
 
 fn main() {
-    let b = DropTracer(0);
-    println!(&quot;a contains {}&quot;, b.0);
+    let a = DropTracer(0);
+    println!(&quot;a contains {}&quot;, a.0);
 
     let mut b = Box::new(DropTracer(1));
     println!(&quot;b contains {}&quot;, b.0);

--- a/src/slide-37.md
+++ b/src/slide-37.md
@@ -16,8 +16,8 @@ impl Drop for DropTracer {
 }
 
 fn main() {
-    let b = DropTracer(0);
-    println!("a contains {}", b.0);
+    let a = DropTracer(0);
+    println!("a contains {}", a.0);
 
     let mut b = Box::new(DropTracer(1));
     println!("b contains {}", b.0);


### PR DESCRIPTION
Tested with an `mdbook serve` and verifying contents of slide 37

<img width="629" alt="Screen Shot 2019-07-08 at 4 00 05 PM" src="https://user-images.githubusercontent.com/1272270/60803750-85e5aa00-a199-11e9-9059-b5f1d0c2ddf5.png">
